### PR TITLE
scripts: Fix the llvm-project not found problem

### DIFF
--- a/scripts/core-utils/clone-llvm.sh
+++ b/scripts/core-utils/clone-llvm.sh
@@ -11,7 +11,7 @@ echo -e "\nLLVM TOOLS_DIR : $TOOLS_DIR"
 TOOLS_SRC_DIR=$TOOLS_DIR/src
 LLVM_TOOLS_SRC_DIR=${TOOLS_SRC_DIR}/llvm-tools
 
-if [[ ! -d ${LLVM_TOOLS_SRC_DIR} ]] ; then
+if [[ ! -d "${LLVM_TOOLS_SRC_DIR}/llvm-project" ]] ; then
 
 	mkdir -p ${LLVM_TOOLS_SRC_DIR}
 	cd ${LLVM_TOOLS_SRC_DIR}


### PR DESCRIPTION
When llvm-project download failed, it will not create the folder. However, the src/llvm-tools folder already create. It will cause the condition block when try to the second build.

Check the llvm-project to make sure the LLVM is already download.