### PR TITLE
tools: add glibc2.38 for rootfs

### DIFF
--- a/scripts/utils/build-rootfs-img.sh
+++ b/scripts/utils/build-rootfs-img.sh
@@ -173,7 +173,7 @@ if [[ ! -f ${SVM_DESTINATION}/svm.sh ]]; then
 	echo -e '#!/bin/sh\n\n/usr/gunyah/crosvm --no-syslog run --disable-sandbox \\'  > ./svm.sh
 	echo -e '--serial=type=stdout,hardware=virtio-console,console,stdin,num=1 \\' >> ./svm.sh
 	echo -e '--serial=type=stdout,hardware=serial,earlycon,num=1 \\' >> ./svm.sh
-	echo -e '--initrd /usr/gunyah/initrd.img  --no-balloon --no-rng \\' >> ./svm.sh
+	echo -e '--initrd /usr/gunyah/initrd.img --no-rng \\' >> ./svm.sh
 	echo -e '--params "rw root=/dev/ram rdinit=/sbin/init earlyprintk=serial panic=0" \\' >> ./svm.sh
 	echo -e ' /usr/gunyah/Image $@\n' >> ./svm.sh
 
@@ -212,16 +212,19 @@ if [[ ! -f ${ROOTFS_REFERENCE_DIR}/lib/libgcc_s.so.1 ]]; then
 		git config --global color.ui auto
 	fi
 
-	ROOTFS_IMAGE_TO_BUILD="rpb-console-image"
+	ROOTFS_IMAGE_TO_BUILD="libgcc"
 	export MACHINE=qemuarm64
 	export DISTRO=rpb
+	if [[ ! -d ${ROOTFS_BASE}/oe-rpb ]]; then
+		mkdir ${ROOTFS_BASE}/oe-rpb
+		cd ${ROOTFS_BASE}/oe-rpb
 
-	mkdir ${ROOTFS_BASE}/oe-rpb
-	cd ${ROOTFS_BASE}/oe-rpb
-
-	# fetch
-	~/bin/repo init -u https://github.com/96boards/oe-rpb-manifest.git -b qcom/master
-	~/bin/repo sync
+		# fetch
+		~/bin/repo init -u https://github.com/96boards/oe-rpb-manifest.git -b qcom/master
+		~/bin/repo sync
+	else
+    	cd ${ROOTFS_BASE}/oe-rpb
+	fi
 
 	# add config for libgcc and other virtualization options
 	echo -e "\n" > ./extra_local.conf
@@ -249,15 +252,50 @@ if [[ ! -f ${ROOTFS_REFERENCE_DIR}/lib/libgcc_s.so.1 ]]; then
 	bitbake ${ROOTFS_IMAGE_TO_BUILD}
 
 	# Completed the build. The file libgcc_s.so.1 should be available at path
-	# ${ROOTFS_BASE}/oe-rpb/build/tmp-rpb-glibc/sysroots-components/cortexa57/libgcc/usr/lib/libgcc_s.so.1
-	LIBGCC_OUT_PATH="build/tmp-rpb-glibc/sysroots-components/cortexa57/libgcc/usr/lib"
+	# ${ROOTFS_BASE}/oe-rpb/build/tmp-rpb/sysroots-components/cortexa57/libgcc/usr/lib/libgcc_s.so.1
+	LIBGCC_OUT_PATH="build/tmp-rpb/sysroots-components/cortexa57/libgcc/usr/lib"
 
 	sudo cp ${ROOTFS_BASE}/oe-rpb/${LIBGCC_OUT_PATH}/libgcc_s.so.1 ${ROOTFS_REFERENCE_DIR}/lib
 	sudo chmod 0755 ${ROOTFS_REFERENCE_DIR}/lib/libgcc_s.so.1
 
-	rm -rf ${ROOTFS_BASE}/oe-rpb
+	# rm -rf ${ROOTFS_BASE}/oe-rpb
 fi
 
+echo "check glibc "
+GLIBC_VER_3x=$(strings ${ROOTFS_REFERENCE_DIR}/lib/libc.so.6 | grep "GLIBC_2.3")
+echo "check glibc GLIBC_VER_3x : ${GLIBC_VER_3x}"
+if [[ ! ${GLIBC_VER_3x} =~ "GLIBC_2.38" ]]; then
+	echo "start build GLIBC_2.38"
+	cd ${ROOTFS_BASE}
+
+	if [[ ! -d $ROOTFS_BASE/glibc-2.38-br-out ]]; then
+		if [[ ! -d $ROOTFS_BASE/glibc-2.38 ]]; then
+			wget https://ftp.gnu.org/gnu/glibc/glibc-2.38.tar.gz
+			tar -xvf glibc-2.38.tar.gz
+		fi
+
+		cd glibc-2.38
+
+		rm -rf build-aarch64
+		mkdir build-aarch64
+		cd build-aarch64
+		CC=aarch64-linux-gnu-gcc
+		CXX=aarch64-linux-gnu-g++
+
+		../configure \
+		--host=aarch64-linux-gnu \
+		--build=aarch64-linux-gnu \
+		--prefix=$ROOTFS_BASE/glibc-2.38-br-out
+
+		make
+		make install
+	fi
+
+	sudo cp -vf $ROOTFS_BASE/glibc-2.38-br-out/lib/libc.so.6 $ROOTFS_REFERENCE_DIR/lib/
+
+else
+    echo "GLIBC_2.38 exist . pass ...."
+fi
 echo "Successfully created the reference files folder for rootfs image at : `pwd`"
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixup the problem that crosvm depends on glibc2.38

Related issue [svm.sh not working](https://github.com/quic/gunyah-support-scripts/issues/13)