### PR TITLE
Provide the local initramfs instead of snapshots.linaro.org

### DIFF
--- a/build_qemuarm64_initramfs.md
+++ b/build_qemuarm64_initramfs.md
@@ -1,0 +1,90 @@
+# Build qemuarm64 initramfs
+## Build
+To build qemuarm64 initramfs image, we should clone Yocto **poky** and **meta-qcom** .  
+The method as follows:  
+
+```bash
+mkdir initramfs-tiny-image
+cd initramfs-tiny-image/
+
+git clone https://git.yoctoproject.org/poky
+cd poky
+git switch styhead 
+
+git clone https://git.yoctoproject.org/meta-qcom
+cd meta-qcom
+git switch styhead
+
+cd ..
+source oe-init-build-env build-qemuarm64
+# then will auto-change dir to build-qemuarm64
+
+vim conf/bblayers.conf
+# In BBLAYERS add meta-qcom with path
+
+vim conf/local.conf
+# Change MACHINE val to qemuarm64
+# Add: INIT_MANAGER = "systemd"
+
+bitbake initramfs-tiny-image
+```
+
+## Convert the image
+After `bitbake` build successfully, we get `initramfs-tiny-image-qemuarm64.cpio.gz` . It is not EXT4 image, which is needed by **gunyah-support-scripts**.  
+It is neccessary to convert this image:  
+
+```bash
+#!/bin/bash
+
+CPIO_GZ_FILE="initramfs-tiny-image-qemuarm64.cpio.gz"
+EXTRACT_DIR="rootfs_temp"
+EXT4_IMAGE="rootfs_ext4.img"
+EXT4_SIZE_MB="512"  # image size in MB
+
+echo "Step 1: Extracting ${CPIO_GZ_FILE}..."
+mkdir -p ${EXTRACT_DIR}
+gzip -d -c -k ${CPIO_GZ_FILE} | (cd ${EXTRACT_DIR} && cpio -idm) 
+
+echo "Step 2: Creating empty ${EXT4_IMAGE} file..."
+dd if=/dev/zero of=${EXT4_IMAGE} bs=1M count=${EXT4_SIZE_MB} status=progress
+mkfs.ext4 -F ${EXT4_IMAGE}
+
+echo "Step 3: Copying contents into ${EXT4_IMAGE}..."
+MOUNT_DIR="mnt_ext4"
+mkdir -p ${MOUNT_DIR}
+sudo mount -o loop ${EXT4_IMAGE} ${MOUNT_DIR}
+sudo cp -a ${EXTRACT_DIR}/* ${MOUNT_DIR}/
+sudo chown -R root:root ${MOUNT_DIR}
+sudo umount ${MOUNT_DIR}
+rmdir ${MOUNT_DIR}
+
+echo "Step 4: Cleaning up and compressing..."
+rm -rf ${EXTRACT_DIR}
+gzip -k -f ${EXT4_IMAGE}
+
+echo "Conversion complete. Your ext4.gz image is: ${EXT4_IMAGE}.gz"
+```
+
+## Use the image
+Copy the `rootfs_ext4.img.gz` to Docker container, such as:  
+
+```bash
+cp <your_yocto_build_dir>/rootfs_ext4.img.gz ~/work/Gunyah/share/
+
+cd <your_gunyah_support_scripts_dir>
+export HOST_TO_DOCKER_SHARED_DIR=~/work/Gunyah/share
+./scripts/run-docker.sh
+
+# Get in docker container, exec:
+cp ~/share/rootfs_ext4.img.gz ~/mnt/workspace/
+
+# exit docker container
+```
+
+Then, while run `build-docker-img.sh`, it will ask:  
+```
+Do you want to provide a local rootfs image file? (y/n)
+```
+Answer **y**, and input the image path in your docker container, such as: `/home/<your_name>/mnt/workspace/rootfs_ext4.img.gz` 
+
+Now, qemuarm64 initramfs image is ready for you.

--- a/quickstart.md
+++ b/quickstart.md
@@ -96,6 +96,9 @@ cd ~/gunyah/gunyah-support-scripts/scripts
 ```
 If any errors occur, refer to above pitfalls and remedies. After this script completes successfully the docker image and other volumes are ready to be used.
 
+> NOTICE: In `build-docker-img.sh` it will download Linaro stock rootfs image, but this rootfs image is not available on snapshots.linaro.org. It is better to provide a local rootfs image file, while the script ask.  
+> The local build method please refer to [Build qemuarm64 initramfs](build_qemuarm64_initramfs.md).
+
 --------
 
 ## Launch Docker environment

--- a/scripts/utils/build-rootfs-img.sh
+++ b/scripts/utils/build-rootfs-img.sh
@@ -84,16 +84,33 @@ else
 
 	cd ${ROOTFS_LINARO_STOCK}
 
-	echo "Now downloading Linaro reference rootfs image"
+	echo "The default snapshots.linaro.org download link may not be available."
+	read -p "Do you want to provide a local rootfs image file? (y/n): " use_local
 
-	# Download the rootfs image $LINARO_ROOTFS_IMAGE from linaro website
-	if [[ ! -f  ${ROOTFS_LINARO_STOCK}/${LINARO_ROOTFS_IMAGE_FILE_NAME} ]]; then
-		wget ${LINARO_ROOTFS_URL}/${LINARO_ROOTFS_IMAGE}
-
-		echo "Download completed, decompressing the image"
-
-		# Decompress the image LINARO_ROOTFS_IMAGE as LINARO_ROOTFS_IMAGE_FILE_NAME
-		gunzip ${LINARO_ROOTFS_IMAGE}
+	if [[ "$use_local" =~ ^[Yy]$ ]]; then
+		read -p "Enter full path to local rootfs image file (must be ext4 or ext4.gz): " local_img
+		if [[ ! -f "$local_img" ]]; then
+			echo "Error: File not found: $local_img"
+			exit 1
+		fi
+		# Copy the local file to expected name
+		if [[ "$local_img" == *.gz ]]; then
+			cp "$local_img" ./${LINARO_ROOTFS_IMAGE}
+			echo "Decompressing the image..."
+			gunzip -f ${LINARO_ROOTFS_IMAGE}
+		else
+			# Assume it's an ext4 file; copy directly to the ext4 filename
+			cp "$local_img" ./${LINARO_ROOTFS_IMAGE_FILE_NAME}
+		fi
+	else
+		echo "Attempting to download from ${LINARO_ROOTFS_URL}..."
+		# Download the rootfs image $LINARO_ROOTFS_IMAGE from linaro website
+		if [[ ! -f  ${ROOTFS_LINARO_STOCK}/${LINARO_ROOTFS_IMAGE_FILE_NAME} ]]; then
+			wget ${LINARO_ROOTFS_URL}/${LINARO_ROOTFS_IMAGE}
+			echo "Download completed, decompressing the image"
+			# Decompress the image LINARO_ROOTFS_IMAGE as LINARO_ROOTFS_IMAGE_FILE_NAME
+			gunzip ${LINARO_ROOTFS_IMAGE}
+		fi
 	fi
 
 	# It would be nice if resize works, but newer e2fsck is needed TBD later!!


### PR DESCRIPTION
Since the download link on `snapshots.linaro.org` is currently unavailable (referenced in [gunyah-support-scripts issue #22](https://github.com/quic/gunyah-support-scripts/issues/22)), I have built the `qemuarm64` initramfs image locally. The image is then copied into the Docker container, and the workflow is now functioning correctly. Please review.